### PR TITLE
Fix code scanning alert no. 64: Missing function level access control

### DIFF
--- a/Adrians/Controllers/AdminController.cs
+++ b/Adrians/Controllers/AdminController.cs
@@ -48,6 +48,7 @@ namespace Adrians.Controllers
         }
 
         [HttpGet]
+        [Authorize(Roles = "Administrator")]
         public async Task<IActionResult> Edit(string id)
         {
             var role = await _roleManager.FindByIdAsync(id);
@@ -59,6 +60,7 @@ namespace Adrians.Controllers
         }
 
         [HttpPost]
+        [Authorize(Roles = "Administrator")]
         public async Task<IActionResult> Edit(RoleModel role)
         {
             if (ModelState.IsValid)


### PR DESCRIPTION
Fixes [https://github.com/Vigdals/AdriansVevside/security/code-scanning/64](https://github.com/Vigdals/AdriansVevside/security/code-scanning/64)

To fix the problem, we need to ensure that the `Edit` action method is protected by an authorization check. The best way to do this in an ASP.NET Core MVC application is to use the `[Authorize]` attribute. Since the `Index` method is protected by `[Authorize(Roles = "Administrator")]`, we should apply the same attribute to the `Edit` method to ensure consistency and proper access control.

- Add the `[Authorize(Roles = "Administrator")]` attribute to both the `HttpGet` and `HttpPost` versions of the `Edit` method.
- This change should be made in the `Adrians/Controllers/AdminController.cs` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
